### PR TITLE
Fix Python 3.8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- make compatible with Python 3.8
+  - use backport of importlib.resources
+  - work around fastapi/starlette bugs leading to 404s for static files
+
 ### Changed
 
 - update Github actions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "nicegui",
     "pywebview",
     "plotly",
+    "fastapi<=0.115.6;python_version<'3.9'",
+    "importlib_resources;python_version<'3.9'",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/src/phantomhv/webui_components.py
+++ b/src/phantomhv/webui_components.py
@@ -3,9 +3,13 @@ Components for the Web UI.
 """
 
 import collections
-import importlib
 import time
 import types
+
+try:
+    from importlib.resources import files
+except ImportError:  # Python <3.9
+    from importlib_resources import files
 
 from nicegui import app, ui, run, elements
 import numpy as np
@@ -112,7 +116,7 @@ class PhantomHVWebUI:
         )
 
         app.add_static_files(
-            "/woff2", importlib.resources.files("phantomhv") / "resources" / "woff2"
+            "/woff2", files("phantomhv") / "resources" / "woff2"
         )
         ui.add_head_html(
             r"""


### PR DESCRIPTION
Two issues surfaced on Python 3.8:

- a backport of `importlib.resources` is needed to easily get the paths of packaged resources
- a recent change in starlette lead to 404s for static resources, see https://github.com/zauberzeug/nicegui/issues/4255
